### PR TITLE
#ifndef to avoid "Redefinition of class error"

### DIFF
--- a/HT1632.h
+++ b/HT1632.h
@@ -1,3 +1,6 @@
+#ifndef HT1632_H_
+#define HT1632_H_
+
 #if(ARDUINO >= 100)
  #include <Arduino.h>
 #else
@@ -101,3 +104,6 @@ class HT1632LEDMatrix : public Print {
   uint8_t matrixNum, _width, _height;
   uint8_t cursor_x, cursor_y, textsize, textcolor;
 };
+
+
+#endif /* HT1632_H_ */


### PR DESCRIPTION
I was getting this error while using Eclipse IDE... Most libraries wrap main header file in `#ifndef`, but this library did not.   This caused the header file to be included multiple times when using standard C++ IDEs. This works when using Arduino IDE because it's not a real IDE :)

```
make all 
Building file: ../.ino.cpp
Starting C++ compile
"/Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/bin/avr-g++" -c -g -Os -fno-exceptions -ffunction-sections -fdata-sections -MMD -mmcu=atmega328p -DF_CPU=16000000L -DARDUINO=156-r2 -DARDUINO_AVR_UNO -DARDUINO_ARCH_AVR    -I"/Applications/Arduino.app/Contents/Resources/Java/hardware/arduino/avr/cores/arduino" -I"/Applications/Arduino.app/Contents/Resources/Java/hardware/arduino/avr/variants/standard" -I"/Users/kig/arduino/libraries/HT1632" -MMD -MP -MF".ino.cpp.d" -MT".ino.cpp.d" -D__IN_ECLIPSE__=1 -x c++ "../.ino.cpp"  -o  ".ino.cpp.o"   -Wall
In file included from ../LEDMatrix.ino:1,
                 from ../.ino.cpp:12:
/Users/kig/arduino/libraries/HT1632/HT1632.h:30: error: redefinition of 'class HT1632'
/Users/kig/arduino/libraries/HT1632/HT1632.h:30: error: previous definition of 'class HT1632'
/Users/kig/arduino/libraries/HT1632/HT1632.h:57: error: redefinition of 'class HT1632LEDMatrix'
/Users/kig/arduino/libraries/HT1632/HT1632.h:57: error: previous definition of 'class HT1632LEDMatrix'
make: *** [.ino.cpp.o] Error 1
```
