### PR TITLE
Suggest adding pinMode OUTPUT in example code. 

### DIFF
--- a/examples/basicdemo/basicdemo.ino
+++ b/examples/basicdemo/basicdemo.ino
@@ -15,6 +15,9 @@ Multiple HT1632's can share data and write pins, but need unique CS pins.
 Adafruit_HT1632 matrix = Adafruit_HT1632(HT_DATA, HT_WR, HT_CS);
 
 void setup() {
+  pinMode(HT_DATA, OUTPUT);
+  pinMode(HT_WR, OUTPUT);
+  pinMode(HT_CS, OUTPUT);  
   Serial.begin(9600);
   matrix.begin(ADA_HT1632_COMMON_16NMOS);
   

--- a/examples/matrixdemo/matrixdemo.ino
+++ b/examples/matrixdemo/matrixdemo.ino
@@ -11,6 +11,10 @@ Adafruit_HT1632LEDMatrix matrix = Adafruit_HT1632LEDMatrix(HT_DATA, HT_WR, HT_CS
 //Adafruit_HT1632LEDMatrix matrix = Adafruit_HT1632LEDMatrix(HT_DATA, HT_WR, HT_CS, HT_CS2);
 
 void setup() {
+  pinMode(HT_DATA, OUTPUT);
+  pinMode(HT_WR, OUTPUT);
+  pinMode(HT_CS, OUTPUT);
+  pinMode(HT_CS2, OUTPUT);
   Serial.begin(9600);
   matrix.begin(ADA_HT1632_COMMON_16NMOS);  
   matrix.fillScreen();

--- a/examples/matrixshapes/matrixshapes.ino
+++ b/examples/matrixshapes/matrixshapes.ino
@@ -12,6 +12,10 @@
 Adafruit_HT1632LEDMatrix matrix = Adafruit_HT1632LEDMatrix(HT_DATA, HT_WR, HT_CS, HT_CS2);
 
 void setup() {
+  pinMode(HT_DATA, OUTPUT);
+  pinMode(HT_WR, OUTPUT);
+  pinMode(HT_CS, OUTPUT);
+  pinMode(HT_CS2, OUTPUT);
   Serial.begin(9600);
   matrix.begin(ADA_HT1632_COMMON_16NMOS);  
   matrix.fillScreen();


### PR DESCRIPTION
This is a suggestion to add pinMode(.., OUTPUT) to all of the pins in the example code. I do see pinMode(..., OUTPUT) in the library but I think I had to explicitly set it if I was using additional matrices or alternative arduino boards.