### PR TITLE
Add rotation support for Adafruit_HT1632LEDMatrix

### DIFF
--- a/Adafruit_HT1632.cpp
+++ b/Adafruit_HT1632.cpp
@@ -61,6 +61,21 @@ void Adafruit_HT1632LEDMatrix::clrPixel(uint8_t x, uint8_t y) {
 void Adafruit_HT1632LEDMatrix::drawPixel(int16_t x, int16_t y, uint16_t color) {
   if((x < 0) || (x >= _width) || (y < 0) || (y >= _height)) return;
 
+  switch(rotation) {
+    case 1:
+      ht1632swap(x, y)
+      x = _height - 1 - x;
+      break;
+    case 2:
+      x = _width - 1 - x;
+      y = _height - 1 - y;
+      break;
+    case 3:
+      ht1632swap(x, y)
+      y = _width - 1 - y;
+      break;
+  }
+
   uint8_t m;
   // figure out which matrix controller it is
   m = x / 24;

--- a/examples/rotationtest/rotationtest.ino
+++ b/examples/rotationtest/rotationtest.ino
@@ -1,0 +1,47 @@
+#include "Adafruit_GFX.h"
+#include "Adafruit_HT1632.h"
+
+#define HT_DATA 2
+#define HT_WR   3
+#define HT_CS   4
+#define HT_CS2  5
+
+// Use this line for single matrix
+Adafruit_HT1632LEDMatrix matrix = Adafruit_HT1632LEDMatrix(HT_DATA, HT_WR, HT_CS);
+// Use this line for two matrices!
+//Adafruit_HT1632LEDMatrix matrix = Adafruit_HT1632LEDMatrix(HT_DATA, HT_WR, HT_CS, HT_CS2);
+
+void setup() {
+  Serial.begin(9600);
+  matrix.begin(ADA_HT1632_COMMON_16NMOS);  
+}
+
+void loop() {
+  testRotation(0); // This is the default
+  testRotation(1);
+  testRotation(2);
+  testRotation(3);
+  matrix.clearScreen();
+}
+
+void testRotation(uint8_t r) {
+  matrix.clearScreen();
+
+  // Print the current rotation then wait a bit
+  matrix.setRotation(r);
+  matrix.setCursor(0, 0);
+  matrix.print(r);
+  matrix.writeScreen();
+  delay(500);
+
+  matrix.clearScreen();
+
+  // Light up each pixel starting from the top left to bottom right then wait a bit
+  for (uint8_t y=0; y<matrix.height(); y++) {   // Every row
+    for (uint8_t x=0; x< matrix.width(); x++) { // Every column
+      matrix.setPixel(x, y);
+      matrix.writeScreen();
+    }
+  }
+  delay(500);
+}


### PR DESCRIPTION
This change implements rotation support for the `Adafruit_HT1632LEDMatrix` class. Originally the `setRotation()` call in the Adafruit GFX library did not work since the `rotation` value was ignored by the `drawPixel()` function. The idea for these changes come directly from other Adafruit libraries for example the RGB matrix panel: https://github.com/adafruit/RGB-matrix-Panel/blob/master/RGBmatrixPanel.cpp#L279-L292

These changes were tested with a new example named `rotationtest` which I have included in this PR. I have included a .gif of the video I took of the example running via an Arduino Uno with a single matrix panel.

![rotate](https://user-images.githubusercontent.com/1531139/27513041-2873b12c-5926-11e7-814d-0b7c86488b10.gif)